### PR TITLE
Fix JSON parsing error 504

### DIFF
--- a/lib/response/parse_json.rb
+++ b/lib/response/parse_json.rb
@@ -5,10 +5,11 @@ module Taxy
   module Response
     class ParseJson < Faraday::Response::Middleware
       WHITESPACE_REGEX = /\A^\s*$\z/
+      GATEWAY_TIMEOUT_REGEX = /504 Gateway Time-out/ # because cabify's API ain't tamed
 
       def parse(body)
         case body
-        when WHITESPACE_REGEX, nil
+        when WHITESPACE_REGEX, GATEWAY_TIMEOUT_REGEX, nil
           nil
         else
           JSON.parse(body, symbolize_names: true)


### PR DESCRIPTION
Cabify API does not return a formatted JSON when it returns from a 504 error. This is the only case found so far that this happens.

In production, this was causing to me:
```ruby
[1] pry(#<Cabify::Client>)> e
=> #<JSON::ParserError: 784: unexpected token at '<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
<script type="text/javascript">
//<![CDATA[
(function() {
var _analytics_scr = document.createElement('script');
_analytics_scr.type = 'text/javascript'; _analytics_scr.async = true; _analytics_scr.src = '/_Incapsula_Resource?SWJIYLWA=719d34d31c8e3a6e6fffd425f7e032f3&ns=3&cb=1867317975';
var _analytics_elem = document.getElementsByTagName('script')[0]; _analytics_elem.parentNode.insertBefore(_analytics_scr, _analytics_elem);
})();
// ]]>
</script></body></html>
'>
```